### PR TITLE
Allow consuming app to handle errors in writing to kinesis

### DIFF
--- a/sample/AmazonKinesisSample/Program.cs
+++ b/sample/AmazonKinesisSample/Program.cs
@@ -43,7 +43,8 @@ namespace AmazonKinesisSample
                     shardCount: shardCount,
                     period: TimeSpan.FromSeconds(2),
                     bufferLogShippingInterval: TimeSpan.FromSeconds(5),
-                    bufferBaseFilename: "./logs/kinesis-buffer"
+                    bufferBaseFilename: "./logs/kinesis-buffer",
+                    onLogSendError: OnLogSendError
                 );
             }
 
@@ -68,6 +69,10 @@ namespace AmazonKinesisSample
 
             Log.Fatal("That's all folks - and all done using {WorkingSet} bytes of RAM", Environment.WorkingSet);
             Console.ReadKey();
+        }
+
+        static void OnLogSendError(object sender, LogSendErrorEventArgs logSendErrorEventArgs) {
+            Console.WriteLine("Error: {0}", logSendErrorEventArgs.Message);
         }
 
         private static void LogStuff()

--- a/src/Serilog.Sinks.AmazonKinesis/KinesisLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/KinesisLoggerConfigurationExtensions.cs
@@ -67,6 +67,7 @@ namespace Serilog
         /// <param name="bufferLogShippingInterval"></param>
         /// <param name="period"></param>
         /// <param name="minimumLogEventLevel"></param>
+        /// <param name="onLogSendError"></param>
         /// <returns>Logger configuration, allowing configuration to continue.</returns>
         /// <exception cref="ArgumentNullException"></exception>
         public static LoggerConfiguration AmazonKinesis(
@@ -79,9 +80,9 @@ namespace Serilog
             int? batchPostingLimit = null,
             TimeSpan? bufferLogShippingInterval = null,
             TimeSpan? period = null,
-            LogEventLevel? minimumLogEventLevel = null)
+            LogEventLevel? minimumLogEventLevel = null,
+            EventHandler<LogSendErrorEventArgs> onLogSendError = null)
         {
-            if (loggerConfiguration == null) throw new ArgumentNullException("loggerConfiguration");
             if (kinesisClient == null) throw new ArgumentNullException("kinesisClient");
             if (streamName == null) throw new ArgumentNullException("streamName");
 
@@ -92,20 +93,11 @@ namespace Serilog
                 BufferLogShippingInterval = KinesisSinkOptions.DefaultBufferLogShippingInterval,
                 Period = period ?? KinesisSinkOptions.DefaultPeriod,
                 BatchPostingLimit = batchPostingLimit ?? KinesisSinkOptions.DefaultBatchPostingLimit,
-                MinimumLogEventLevel = minimumLogEventLevel ?? LevelAlias.Minimum
+                MinimumLogEventLevel = minimumLogEventLevel ?? LevelAlias.Minimum,
+                OnLogSendFail = onLogSendError
             };
 
-            ILogEventSink sink;
-            if (options.BufferBaseFilename == null)
-            {
-                sink = new KinesisSink(options);
-            }
-            else
-            {
-                sink = new DurableKinesisSink(options);
-            }
-
-            return loggerConfiguration.Sink(sink, options.MinimumLogEventLevel ?? LevelAlias.Minimum);
+            return AmazonKinesis(loggerConfiguration, options);
         }
     }
 }

--- a/src/Serilog.Sinks.AmazonKinesis/KinesisLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/KinesisLoggerConfigurationExtensions.cs
@@ -94,7 +94,7 @@ namespace Serilog
                 Period = period ?? KinesisSinkOptions.DefaultPeriod,
                 BatchPostingLimit = batchPostingLimit ?? KinesisSinkOptions.DefaultBatchPostingLimit,
                 MinimumLogEventLevel = minimumLogEventLevel ?? LevelAlias.Minimum,
-                OnLogSendFail = onLogSendError
+                OnLogSendError = onLogSendError
             };
 
             return AmazonKinesis(loggerConfiguration, options);

--- a/src/Serilog.Sinks.AmazonKinesis/Serilog.Sinks.AmazonKinesis-net40.csproj
+++ b/src/Serilog.Sinks.AmazonKinesis/Serilog.Sinks.AmazonKinesis-net40.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Sinks\AmazonKinesis\KinesisSinkState.cs" />
     <Compile Include="Sinks\AmazonKinesis\KinesisApi.cs" />
     <Compile Include="Sinks\AmazonKinesis\DurableKinesisSink.cs" />
+    <Compile Include="Sinks\AmazonKinesis\LogSendErrorEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog.Sinks.AmazonKinesis/Serilog.Sinks.AmazonKinesis.csproj
+++ b/src/Serilog.Sinks.AmazonKinesis/Serilog.Sinks.AmazonKinesis.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Sinks\AmazonKinesis\KinesisSinkState.cs" />
     <Compile Include="Sinks\AmazonKinesis\KinesisApi.cs" />
     <Compile Include="Sinks\AmazonKinesis\DurableKinesisSink.cs" />
+    <Compile Include="Sinks\AmazonKinesis\LogSendErrorEventArgs.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\assets\Serilog.snk">

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/DurableKinesisSink.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/DurableKinesisSink.cs
@@ -40,6 +40,10 @@ namespace Serilog.Sinks.AmazonKinesis
                null);
 
             _shipper = new HttpLogShipper(state);
+
+            if (options.OnLogSendFail != null) {
+                _shipper.LogSendFail += options.OnLogSendFail;
+            }
         }
 
         public void Emit(LogEvent logEvent)

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/DurableKinesisSink.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/DurableKinesisSink.cs
@@ -41,8 +41,8 @@ namespace Serilog.Sinks.AmazonKinesis
 
             _shipper = new HttpLogShipper(state);
 
-            if (options.OnLogSendFail != null) {
-                _shipper.LogSendFail += options.OnLogSendFail;
+            if (options.OnLogSendError != null) {
+                _shipper.LogSendError += options.OnLogSendError;
             }
         }
 

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
@@ -188,7 +188,7 @@ namespace Serilog.Sinks.AmazonKinesis
                                         SelfLog.WriteLine("Kinesis failed to index record in stream '{0}'. {1} {2} ", _state.Options.StreamName, record.ErrorCode, record.ErrorMessage);
                                     }
                                     // fire event
-                                    OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count)));
+                                    OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count),null));
                                 }
                             }
                             else
@@ -227,7 +227,7 @@ namespace Serilog.Sinks.AmazonKinesis
             catch (Exception ex)
             {
                 SelfLog.WriteLine("Exception while emitting periodic batch from {0}: {1}", this, ex);
-                OnLogSendError(new LogSendErrorEventArgs(string.Format("Error in shipping logs to '{0}' stream: {1})", _state.Options.StreamName, ex.Message)));
+                OnLogSendError(new LogSendErrorEventArgs(string.Format("Error in shipping logs to '{0}' stream)", _state.Options.StreamName),ex));
             }
             finally
             {

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
@@ -36,6 +36,7 @@ namespace Serilog.Sinks.AmazonKinesis
         readonly string _bookmarkFilename;
         readonly string _logFolder;
         readonly string _candidateSearchPath;
+        public event EventHandler<LogSendErrorEventArgs> LogSendFail;
 
         public HttpLogShipper(KinesisSinkState state)
         {
@@ -59,6 +60,15 @@ namespace Serilog.Sinks.AmazonKinesis
             CloseAndFlush();
         }
 
+        void OnLogSendError(LogSendErrorEventArgs e)
+        {
+            var handler = LogSendFail;
+            if (handler != null)
+            {
+                handler(this, e);
+            }
+        }
+        
         void CloseAndFlush()
         {
             lock (_stateLock)
@@ -177,6 +187,8 @@ namespace Serilog.Sinks.AmazonKinesis
                                     {
                                         SelfLog.WriteLine("Kinesis failed to index record in stream '{0}'. {1} {2} ", _state.Options.StreamName, record.ErrorCode, record.ErrorMessage);
                                     }
+                                    // fire event
+                                    OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count)));
                                 }
                             }
                             else
@@ -215,6 +227,7 @@ namespace Serilog.Sinks.AmazonKinesis
             catch (Exception ex)
             {
                 SelfLog.WriteLine("Exception while emitting periodic batch from {0}: {1}", this, ex);
+                OnLogSendError(new LogSendErrorEventArgs(string.Format("Error in shipping logs to '{0}' stream: {1})", _state.Options.StreamName, ex.Message)));
             }
             finally
             {

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
@@ -36,7 +36,7 @@ namespace Serilog.Sinks.AmazonKinesis
         readonly string _bookmarkFilename;
         readonly string _logFolder;
         readonly string _candidateSearchPath;
-        public event EventHandler<LogSendErrorEventArgs> LogSendFail;
+        public event EventHandler<LogSendErrorEventArgs> LogSendError;
 
         public HttpLogShipper(KinesisSinkState state)
         {
@@ -62,7 +62,7 @@ namespace Serilog.Sinks.AmazonKinesis
 
         void OnLogSendError(LogSendErrorEventArgs e)
         {
-            var handler = LogSendFail;
+            var handler = LogSendError;
             if (handler != null)
             {
                 handler(this, e);

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/KinesisSinkOptions.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/KinesisSinkOptions.cs
@@ -109,7 +109,7 @@ namespace Serilog.Sinks.AmazonKinesis
         /// <summary>
         /// An eventhandler which will be invoked whenever there is an error in log sending.
         /// </summary>
-        public EventHandler<LogSendErrorEventArgs> OnLogSendFail { get; set; }
+        public EventHandler<LogSendErrorEventArgs> OnLogSendError { get; set; }
         
         /// <summary>
         /// Configures the Amazon Kinesis sink defaults.

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/KinesisSinkOptions.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/KinesisSinkOptions.cs
@@ -106,6 +106,10 @@ namespace Serilog.Sinks.AmazonKinesis
         /// </summary>
         public ITextFormatter CustomDurableFormatter { get; set; }
 
+        /// <summary>
+        /// An eventhandler which will be invoked whenever there is an error in log sending.
+        /// </summary>
+        public EventHandler<LogSendErrorEventArgs> OnLogSendFail { get; set; }
         
         /// <summary>
         /// Configures the Amazon Kinesis sink defaults.

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/LogSendErrorEventArgs.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/LogSendErrorEventArgs.cs
@@ -1,0 +1,30 @@
+using System;
+
+namespace Serilog.Sinks.AmazonKinesis
+{
+    /// <summary>
+    /// Args for event raised when log sending errors.
+    /// </summary>
+    public class LogSendErrorEventArgs : EventArgs
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LogSendErrorEventArgs"/> class.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="exception"></param>
+        public LogSendErrorEventArgs(string message, Exception exception) {
+            Message = message;
+            Exception = exception;
+        }
+
+        /// <summary>
+        /// A message with details of the error.
+        /// </summary>
+        public string Message { get; set; }
+
+        /// <summary>
+        /// The underlying exception.
+        /// </summary>
+        public Exception Exception { get; set; }
+    }
+}


### PR DESCRIPTION
Have created an event which is fired when kinesis returns error records (from PUT) or any exception is thrown.
Consuming app can provide an eventhandler if it wishes to know about these events.

I tested this by just breaking before 
```
PutRecordsResponse response = _state.KinesisClient.PutRecords(request);
```
and blowing away the stream.