### PR TITLE
hack - manually set build to pass prerelease version to nuget pack

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -33,7 +33,7 @@ function Invoke-MSBuild($solution, $customLogger)
 
 function Invoke-NuGetPackSpec($nuspec, $version)
 {
-    nuget pack $nuspec -Version $version
+    nuget pack $nuspec -Version $version-awssdkbeta3
 }
 
 function Invoke-Build($majorMinor, $patch, $customLogger, $notouch)


### PR DESCRIPTION
i need to work out how to change the build number passed in by appveyor - but in the meantime, hacking the build number to prerelease in the build script so it can nuget pack...