### PR TITLE
Don't dispose of Stream in StreamReader

### DIFF
--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
@@ -285,10 +285,8 @@ namespace Serilog.Sinks.AmazonKinesis
 
             current.Position = nextStart;
 
-            using (var reader = new StreamReader(current, Encoding.UTF8, false, 128))
-            {
-                nextLine = reader.ReadLine();
-            }
+            var reader = new StreamReader(current, Encoding.UTF8, false, 128);
+            nextLine = reader.ReadLine();
 
             if (nextLine == null)
                 return false;


### PR DESCRIPTION
In .NET 4.0, disposing the StreamReader also destroys the underlying
Stream. By removing the using here we ensure that the Stream won't be
destroyed. The StreamReader will be later collected by GC, which will
call Finalize(), which doesn't dispose the Stream.

@thirkcircus 