### PR TITLE
Fix another .NET 4.0 StreamReader

### DIFF
--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
@@ -285,6 +285,7 @@ namespace Serilog.Sinks.AmazonKinesis
 
             current.Position = nextStart;
 
+            // Important not to dispose this StreamReader as the stream must remain open.
             var reader = new StreamReader(current, Encoding.UTF8, false, 128);
             nextLine = reader.ReadLine();
 
@@ -306,10 +307,9 @@ namespace Serilog.Sinks.AmazonKinesis
             if (bookmark.Length != 0)
             {
                 string current;
-                using (var reader = new StreamReader(bookmark, Encoding.UTF8, false, 128))
-                {
-                    current = reader.ReadLine();
-                }
+                // Important not to dispose this StreamReader as the stream must remain open.
+                var reader = new StreamReader(bookmark, Encoding.UTF8, false, 128);
+                current = reader.ReadLine();
 
                 if (current != null)
                 {


### PR DESCRIPTION
GC will take care of this StreamReader without disposing the underlying Stream.

This change is similar to https://github.com/serilog/serilog-sinks-amazonkinesis/pull/10, same approach was used in `serilog-sinks-seq` (https://github.com/serilog/serilog-sinks-seq/blob/master/src/Serilog.Sinks.Seq/Sinks/Seq/HttpLogShipper-net40.cs#L294:L295).

@thirkcircus , @superlogical 