### PR TITLE
Fix IO exceptions being swallowed

### DIFF
--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
@@ -1,11 +1,11 @@
 ﻿// Copyright 2014 Serilog Contributors
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,7 +68,7 @@ namespace Serilog.Sinks.AmazonKinesis
                 handler(this, e);
             }
         }
-        
+
         void CloseAndFlush()
         {
             lock (_stateLock)
@@ -188,19 +188,18 @@ namespace Serilog.Sinks.AmazonKinesis
                                         SelfLog.WriteLine("Kinesis failed to index record in stream '{0}'. {1} {2} ", _state.Options.StreamName, record.ErrorCode, record.ErrorMessage);
                                     }
                                     // fire event
-                                    OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count),null));
+                                    OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count), null));
                                 }
                             }
                             else
                             {
                                 SelfLog.WriteLine("Found no records to process");
-    
+
                                 // Only advance the bookmark if no other process has the
                                 // current file locked, and its length is as we found it.
 
                                 var bufferedFilesCount = fileSet.Length;
-                                var isProcessingFirstFile = fileSet.First().Equals(currentFilePath,StringComparison.InvariantCultureIgnoreCase);
-
+                                var isProcessingFirstFile = fileSet.First().Equals(currentFilePath, StringComparison.InvariantCultureIgnoreCase);
                                 //SelfLog.WriteLine("BufferedFilesCount: {0}; IsProcessingFirstFile: {1}; IsFirstFileUnlocked: {2}", bufferedFilesCount, isProcessingFirstFile, isFirstFileUnlocked);
 
                                 if (bufferedFilesCount == 2 && isProcessingFirstFile && IsUnlockedAtLength(currentFilePath, nextLineBeginsAtOffset))
@@ -222,12 +221,13 @@ namespace Serilog.Sinks.AmazonKinesis
                         }
                     }
                 }
+
                 while (count == _batchPostingLimit);
             }
             catch (Exception ex)
             {
                 SelfLog.WriteLine("Exception while emitting periodic batch from {0}: {1}", this, ex);
-                OnLogSendError(new LogSendErrorEventArgs(string.Format("Error in shipping logs to '{0}' stream)", _state.Options.StreamName),ex));
+                OnLogSendError(new LogSendErrorEventArgs(string.Format("Error in shipping logs to '{0}' stream)", _state.Options.StreamName), ex));
             }
             finally
             {


### PR DESCRIPTION
* Only check if the file is locked when 2 other conditions are satisfied.
This will reduce the number of IO exceptions dramatically.

* Error code 32 is actually an IO exception which happens when a file is
locked by another process. As the code is now, this exception is being
caught and then it's being swallowed (no rethrows here).
This should be ==, not !=, see how @nblumhardt does it here:
https://github.com/serilog/serilog-dnx-prerelease/blob/master/src/Serilog.Dnx.Prerelease/Sinks/RollingFile/RollingFileSink.cs#L150

@thirkcircus 