### PR TITLE
Don't advance bookmark if we fail to send logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,7 +125,7 @@ publish/
 # Publish Web Output
 *.[Pp]ublish.xml
 *.azurePubxml
-# TODO: Comment the next line if you want to checkin your web deploy settings 
+# TODO: Comment the next line if you want to checkin your web deploy settings
 # but database connection strings (with potential passwords) will be unencrypted
 *.pubxml
 *.publishproj
@@ -182,3 +182,8 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# NCrunch
+_NCrunch_*
+.*crunch*.local.xml
+*.ncrunch*

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper-net40.cs
@@ -178,9 +178,6 @@ namespace Serilog.Sinks.AmazonKinesis
                                 SelfLog.WriteLine("Writing {0} records to kinesis", count);
                                 PutRecordsResponse response = _state.KinesisClient.PutRecords(request);
 
-                                SelfLog.WriteLine("Advancing bookmark from '{0}' to '{1}'", startingOffset, nextLineBeginsAtOffset);
-                                WriteBookmark(bookmark, nextLineBeginsAtOffset, currentFilePath);
-
                                 if (response.FailedRecordCount > 0)
                                 {
                                     foreach (var record in response.Records)
@@ -189,6 +186,12 @@ namespace Serilog.Sinks.AmazonKinesis
                                     }
                                     // fire event
                                     OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count), null));
+                                }
+                                else
+                                {
+                                    // Advance the bookmark only if we successfully written to Kinesis Stream
+                                    SelfLog.WriteLine("Advancing bookmark from '{0}' to '{1}'", startingOffset, nextLineBeginsAtOffset);
+                                    WriteBookmark(bookmark, nextLineBeginsAtOffset, currentFilePath);
                                 }
                             }
                             else

--- a/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.AmazonKinesis/Sinks/AmazonKinesis/HttpLogShipper.cs
@@ -178,9 +178,6 @@ namespace Serilog.Sinks.AmazonKinesis
                                 SelfLog.WriteLine("Writing {0} records to kinesis", count);
                                 PutRecordsResponse response = _state.KinesisClient.PutRecords(request);
 
-                                SelfLog.WriteLine("Advancing bookmark from '{0}' to '{1}'", startingOffset, nextLineBeginsAtOffset);
-                                WriteBookmark(bookmark, nextLineBeginsAtOffset, currentFilePath);
-
                                 if (response.FailedRecordCount > 0)
                                 {
                                     foreach (var record in response.Records)
@@ -189,6 +186,12 @@ namespace Serilog.Sinks.AmazonKinesis
                                     }
                                     // fire event
                                     OnLogSendError(new LogSendErrorEventArgs(string.Format("Error writing records to {0} ({1} of {2} records failed)", _state.Options.StreamName, response.FailedRecordCount, count),null));
+                                }
+                                else
+                                {
+                                    // Advance the bookmark only if we successfully written to Kinesis Stream
+                                    SelfLog.WriteLine("Advancing bookmark from '{0}' to '{1}'", startingOffset, nextLineBeginsAtOffset);
+                                    WriteBookmark(bookmark, nextLineBeginsAtOffset, currentFilePath);
                                 }
                             }
                             else


### PR DESCRIPTION
This was most certainly a bug - we should check that we succeeded in
sending the logs before we advance the bookmark.

Ideally this should be handled by some kind of retry policy though.

Also add Ncrunch generated files to `.gitignore`.

@thirkcircus , @superlogical 