### PR TITLE
fixed namespace for kinesis.stream liblog

### DIFF
--- a/sample/AmazonKinesisSample/Program.cs
+++ b/sample/AmazonKinesisSample/Program.cs
@@ -43,7 +43,6 @@ namespace AmazonKinesisSample
                     streamName: streamName,
                     shardCount: shardCount,
                     period: TimeSpan.FromSeconds(2),
-                    bufferLogShippingInterval: TimeSpan.FromSeconds(5),
                     bufferBaseFilename: "./logs/kinesis-buffer",
                     onLogSendError: OnLogSendError
                 );

--- a/src/Serilog.Sinks.Amazon.Kinesis.Firehose/Sinks/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis.Firehose/Sinks/HttpLogShipper.cs
@@ -21,7 +21,6 @@ using System.Text;
 using System.Threading;
 using Amazon.KinesisFirehose.Model;
 using Serilog.Debugging;
-using Serilog.Sinks.Amazon.Kinesis;
 using Serilog.Sinks.Amazon.Kinesis.Firehose.Logging;
 
 namespace Serilog.Sinks.Amazon.Kinesis.Firehose

--- a/src/Serilog.Sinks.Amazon.Kinesis.Stream/App_Packages/LibLog.4.2/LibLog.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis.Stream/App_Packages/LibLog.4.2/LibLog.cs
@@ -46,17 +46,17 @@ using System.Diagnostics.CodeAnalysis;
 // If you copied this file manually, you need to change all "YourRootNameSpace" so not to clash with other libraries
 // that use LibLog
 #if LIBLOG_PROVIDERS_ONLY
-namespace Serilog.LibLog
+namespace Serilog.Sinks.Amazon.Kinesis.Stream.LibLog
 #else
-namespace Serilog.Logging
+namespace Serilog.Sinks.Amazon.Kinesis.Stream.Logging
 #endif
 {
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
 #if LIBLOG_PROVIDERS_ONLY
-    using Serilog.LibLog.LogProviders;
+    using Serilog.Sinks.Amazon.Kinesis.Stream.LibLog.LogProviders;
 #else
-    using Serilog.Logging.LogProviders;
+    using Serilog.Sinks.Amazon.Kinesis.Stream.Logging.LogProviders;
 #endif
     using System;
 #if !LIBLOG_PROVIDERS_ONLY
@@ -722,9 +722,9 @@ namespace Serilog.Logging
 }
 
 #if LIBLOG_PROVIDERS_ONLY
-namespace Serilog.LibLog.LogProviders
+namespace Serilog.Sinks.Amazon.Kinesis.Stream.LibLog.LogProviders
 #else
-namespace Serilog.Logging.LogProviders
+namespace Serilog.Sinks.Amazon.Kinesis.Stream.Logging.LogProviders
 #endif
 {
     using System;

--- a/src/Serilog.Sinks.Amazon.Kinesis.Stream/Sinks/AmazonKinesis/HttpLogShipper.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis.Stream/Sinks/AmazonKinesis/HttpLogShipper.cs
@@ -20,7 +20,7 @@ using System.Text;
 using System.Threading;
 using Amazon.Kinesis.Model;
 using Serilog.Debugging;
-using Serilog.Logging;
+using Serilog.Sinks.Amazon.Kinesis.Stream.Logging;
 using IO = System.IO;
 
 namespace Serilog.Sinks.Amazon.Kinesis.Stream


### PR DESCRIPTION
the original install of liblog must have borked the namespace.  
fixing.