### PR TITLE
Fix: BufferBaseFilename property always returned non-empty string

### DIFF
--- a/src/Serilog.Sinks.Amazon.Kinesis/Common/KinesisSinkOptionsBase.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Common/KinesisSinkOptionsBase.cs
@@ -23,7 +23,7 @@ namespace Serilog.Sinks.Amazon.Kinesis
         /// </summary>
         public string BufferBaseFilename
         {
-            get { return _bufferBaseFilename + BufferBaseFilenameAppend; }
+            get { return string.IsNullOrEmpty(_bufferBaseFilename) ? null : _bufferBaseFilename + BufferBaseFilenameAppend; }
             set { _bufferBaseFilename = value; }
         }
 


### PR DESCRIPTION
Configuration extensions always returned durable loggers, even when BufferBaseFilename == null.
Ideally, we should not have non-symmetrical setter and getter for the property, but I don't want to introduce backward compatibility for now.