### PR TITLE
Fix non-symmetric property getter and setter for KinesisSinkOptionsBase.BufferBaseFilename

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ if (streamOk)
     loggerConfig.WriteTo.AmazonKinesis(
         kinesisClient: client,
         streamName: streamName,
-        shardCount: shardCount,
         period: TimeSpan.FromSeconds(2),
         bufferLogShippingInterval: TimeSpan.FromSeconds(5),
         bufferBaseFilename: "./logs/kinesis-buffer"

--- a/src/Serilog.Sinks.Amazon.Kinesis/Common/KinesisSinkOptionsBase.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Common/KinesisSinkOptionsBase.cs
@@ -21,16 +21,7 @@ namespace Serilog.Sinks.Amazon.Kinesis
         /// <summary>
         /// Optional path to directory that can be used as a log shipping buffer for increasing the reliabilty of the log forwarding.
         /// </summary>
-        public string BufferBaseFilename
-        {
-            get { return string.IsNullOrEmpty(_bufferBaseFilename) ? null : _bufferBaseFilename + BufferBaseFilenameAppend; }
-            set { _bufferBaseFilename = value; }
-        }
-
-        /// <summary>
-        /// Will be appended to buffer base filenames.
-        /// </summary>
-        public abstract string BufferBaseFilenameAppend { get; }
+        public string BufferBaseFilename { get; set; }
 
         /// <summary>
         /// The default time to wait between checking for event batches. Defaults to 2 seconds.
@@ -40,9 +31,7 @@ namespace Serilog.Sinks.Amazon.Kinesis
         /// <summary>
         /// The default maximum number of events to post in a single batch. Defaults to 500.
         /// </summary>
-        public static int DefaultBatchPostingLimit = 500;
-
-        string _bufferBaseFilename;
+        public static readonly int DefaultBatchPostingLimit = 500;
 
         /// <summary>
         /// The default stream name to use for the log events.

--- a/src/Serilog.Sinks.Amazon.Kinesis/Firehose/KinesisFirehoseLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Firehose/KinesisFirehoseLoggerConfigurationExtensions.cs
@@ -88,9 +88,9 @@ namespace Serilog
             var options = new KinesisFirehoseSinkOptions(streamName)
             {
                 BufferFileSizeLimitBytes = bufferFileSizeLimitBytes,
-                BufferBaseFilename = bufferBaseFilename,
-                Period = period ?? KinesisFirehoseSinkOptions.DefaultPeriod,
-                BatchPostingLimit = batchPostingLimit ?? KinesisFirehoseSinkOptions.DefaultBatchPostingLimit,
+                BufferBaseFilename = bufferBaseFilename == null ? null : bufferBaseFilename + ".firehose",
+                Period = period ?? KinesisSinkOptionsBase.DefaultPeriod,
+                BatchPostingLimit = batchPostingLimit ?? KinesisSinkOptionsBase.DefaultBatchPostingLimit,
                 MinimumLogEventLevel = minimumLogEventLevel ?? LevelAlias.Minimum,
                 OnLogSendError = onLogSendError
             };

--- a/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/KinesisFirehoseSinkOptions.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Firehose/Sinks/KinesisFirehoseSinkOptions.cs
@@ -24,13 +24,5 @@ namespace Serilog.Sinks.Amazon.Kinesis.Firehose.Sinks
         /// </summary>
         /// <param name="streamName">The name of the Kinesis stream.</param>
         public KinesisFirehoseSinkOptions(string streamName) : base(streamName) {}
-
-        /// <summary>
-        ///     Will be appended to buffer base filenames.
-        /// </summary>
-        public override string BufferBaseFilenameAppend
-        {
-            get { return ".firehose"; }
-        }
     }
 }

--- a/src/Serilog.Sinks.Amazon.Kinesis/Stream/KinesisLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Stream/KinesisLoggerConfigurationExtensions.cs
@@ -87,9 +87,9 @@ namespace Serilog
             var options = new KinesisStreamSinkOptions(streamName: streamName)
             {
                 BufferFileSizeLimitBytes = bufferFileSizeLimitBytes,
-                BufferBaseFilename = bufferBaseFilename,
-                Period = period ?? KinesisStreamSinkOptions.DefaultPeriod,
-                BatchPostingLimit = batchPostingLimit ?? KinesisStreamSinkOptions.DefaultBatchPostingLimit,
+                BufferBaseFilename = bufferBaseFilename == null ? null : bufferBaseFilename + ".stream",
+                Period = period ?? KinesisSinkOptionsBase.DefaultPeriod,
+                BatchPostingLimit = batchPostingLimit ?? KinesisSinkOptionsBase.DefaultBatchPostingLimit,
                 MinimumLogEventLevel = minimumLogEventLevel ?? LevelAlias.Minimum,
                 OnLogSendError = onLogSendError
             };

--- a/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisStreamSinkOptions.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Stream/Sinks/KinesisStreamSinkOptions.cs
@@ -26,13 +26,5 @@ namespace Serilog.Sinks.Amazon.Kinesis.Stream.Sinks
         public KinesisStreamSinkOptions(string streamName) : base(streamName)
         {
         }
-
-        /// <summary>
-        ///     Will be appended to buffer base filenames.
-        /// </summary>
-        public override string BufferBaseFilenameAppend
-        {
-            get { return ".stream"; }
-        }
     }
 }


### PR DESCRIPTION
Remove `KinesisSinkOptionsBase.BufferBaseFilenameAppend` property, and append ".stream" or ".firehose" suffix to `BufferBaseFileName` property in `KinesisLoggerConfigurationExtensions` and `KinesisFirehoseLoggerConfigurationExtensions` classes.

**Breaking change:** ".stream" or ".firehose" suffix is not automatically added to `BufferBaseFilename` when creating instances of `KinesisFirehoseSinkOptions` or `KinesisStreamSinkOptions`.
However, code which uses KinesisLoggerConfigurationExtensions or KinesisFirehoseLoggerConfigurationExtensions will not change it's behaviour.

Closes #31
@serilog/reviewers-amazon-kinesis 