### PR TITLE
Updated solution for using .NET 4.5 and Serilog 2.x

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,5 +1,5 @@
 param(
-    [String] $majorMinor = "2.0",  # 2.0
+    [String] $majorMinor = "2.1",  # 2.1
     [String] $patch = "0",         # $env:APPVEYOR_BUILD_VERSION
     [String] $customLogger = "",   # C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll
     [Switch] $notouch

--- a/sample/AmazonKinesisSample/AmazonKinesisSample.csproj
+++ b/sample/AmazonKinesisSample/AmazonKinesisSample.csproj
@@ -47,7 +47,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.4.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.ColoredConsole, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/sample/AmazonKinesisSample/AmazonKinesisSample.csproj
+++ b/sample/AmazonKinesisSample/AmazonKinesisSample.csproj
@@ -46,12 +46,12 @@
       <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net45\AWSSDK.Kinesis.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.4.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net45\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Sinks.ColoredConsole, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.ColoredConsole.2.0.0\lib\net45\Serilog.Sinks.ColoredConsole.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/sample/AmazonKinesisSample/App.config
+++ b/sample/AmazonKinesisSample/App.config
@@ -1,9 +1,9 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <!--    <add key="AWSAccessKey" value="YOUR_ACCESS_KEY"/>-->
     <!--    <add key="AWSSecretKey" value="YOUR_SECRET_KEY"/>-->
-    <add key="AWSRegion" value="us-east-1" />
+    <add key="AWSRegion" value="us-east-1"/>
     <!--AWSProfileName is used to reference an account that has been registered with the SDK.
 If using AWS Toolkit for Visual Studio then this value is the same value shown in the AWS Explorer.
 It is also possible to register an account using the <solution-dir>/packages/AWSSDK-X.X.X.X/tools/account-management.ps1 PowerShell script
@@ -12,4 +12,13 @@ that is bundled with the nuget package under the tools folder.
 		<add key="AWSProfileName" value="" />
 -->
   </appSettings>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
 </configuration>

--- a/sample/AmazonKinesisSample/Program.cs
+++ b/sample/AmazonKinesisSample/Program.cs
@@ -23,7 +23,7 @@ namespace AmazonKinesisSample
 
         public static void Main()
         {
-            SelfLog.Out = Console.Out;
+            SelfLog.Enable(Console.Out);
 
             var client = new AmazonKinesisClient();
 

--- a/sample/AmazonKinesisSample/packages.config
+++ b/sample/AmazonKinesisSample/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
   <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
-  <package id="Serilog" version="2.4.0" targetFramework="net45" />
+  <package id="Serilog" version="2.0.0" targetFramework="net45" />
   <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/sample/AmazonKinesisSample/packages.config
+++ b/sample/AmazonKinesisSample/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
   <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
-  <package id="Serilog" version="1.5.14" targetFramework="net45" />
+  <package id="Serilog" version="2.4.0" targetFramework="net452" />
+  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net452" />
 </packages>

--- a/sample/AmazonKinesisSample/packages.config
+++ b/sample/AmazonKinesisSample/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
   <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
-  <package id="Serilog" version="2.4.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net452" />
+  <package id="Serilog" version="2.4.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.Amazon.Kinesis/Common/LogShipperFileManager.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Common/LogShipperFileManager.cs
@@ -6,7 +6,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Common
     {
         public long GetFileLengthExclusiveAccess(string filePath)
         {
-            using (var fileStream = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (var fileStream = System.IO.File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             {
                 return fileStream.Length;
             }

--- a/src/Serilog.Sinks.Amazon.Kinesis/Common/PersistedBookmark.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Common/PersistedBookmark.cs
@@ -20,7 +20,7 @@ namespace Serilog.Sinks.Amazon.Kinesis
 
         public static PersistedBookmark Create(string bookmarkFileName)
         {
-            var stream = File.Open(bookmarkFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
+            var stream = System.IO.File.Open(bookmarkFileName, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.Read);
             try
             {
                 var bookmark = new PersistedBookmark(stream);

--- a/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
@@ -51,11 +51,11 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.4.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.File.3.2.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.Sinks.File.2.2.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
@@ -63,7 +63,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.Sinks.RollingFile.2.2.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Sinks.Amazon.Kinesis</RootNamespace>
     <AssemblyName>Serilog.Sinks.Amazon.Kinesis</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <Framework Condition=" '$(Framework)' == '' ">NET45</Framework>
@@ -50,12 +50,20 @@
       <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.2\lib\net35\AWSSDK.KinesisFirehose.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net40\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.4.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net40\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.File.3.2.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.1.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
@@ -39,15 +39,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net35\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net45\AWSSDK.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.Kinesis, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net35\AWSSDK.Kinesis.dll</HintPath>
+      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net45\AWSSDK.Kinesis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.KinesisFirehose, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.2\lib\net35\AWSSDK.KinesisFirehose.dll</HintPath>
+      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\lib\net45\AWSSDK.KinesisFirehose.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
@@ -105,14 +105,11 @@
     <Compile Include="Stream\Sinks\KinesisStreamSinkOptions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
-  <ItemGroup />
   <ItemGroup>
     <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.1.3.0\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
-    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.1.0.2\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/src/Serilog.Sinks.Amazon.Kinesis/packages.config
+++ b/src/Serilog.Sinks.Amazon.Kinesis/packages.config
@@ -1,8 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net40" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net40" />
-  <package id="AWSSDK.KinesisFirehose" version="3.1.0.2" targetFramework="net40" />
+  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net40" requireReinstallation="true" />
+  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="AWSSDK.KinesisFirehose" version="3.1.0.2" targetFramework="net40" requireReinstallation="true" />
   <package id="LibLog" version="4.2.5" targetFramework="net40" developmentDependency="true" />
-  <package id="Serilog" version="1.5.14" targetFramework="net40" />
+  <package id="Serilog" version="2.4.0" targetFramework="net452" />
+  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net452" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net452" />
+  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
 </packages>

--- a/src/Serilog.Sinks.Amazon.Kinesis/packages.config
+++ b/src/Serilog.Sinks.Amazon.Kinesis/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net40" requireReinstallation="true" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net40" requireReinstallation="true" />
-  <package id="AWSSDK.KinesisFirehose" version="3.1.0.2" targetFramework="net40" requireReinstallation="true" />
-  <package id="LibLog" version="4.2.5" targetFramework="net40" developmentDependency="true" />
-  <package id="Serilog" version="2.4.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
+  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
+  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
+  <package id="AWSSDK.KinesisFirehose" version="3.1.0.3" targetFramework="net45" />
+  <package id="LibLog" version="4.2.5" targetFramework="net45" developmentDependency="true" />
+  <package id="Serilog" version="2.4.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.Amazon.Kinesis/packages.config
+++ b/src/Serilog.Sinks.Amazon.Kinesis/packages.config
@@ -4,8 +4,8 @@
   <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
   <package id="AWSSDK.KinesisFirehose" version="3.1.0.3" targetFramework="net45" />
   <package id="LibLog" version="4.2.5" targetFramework="net45" developmentDependency="true" />
-  <package id="Serilog" version="2.4.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net45" />
+  <package id="Serilog" version="2.0.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.File" version="2.2.0" targetFramework="net45" />
   <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.RollingFile" version="2.2.0" targetFramework="net45" />
 </packages>

--- a/src/Serilog.Sinks.AmazonKinesis.nuspec
+++ b/src/Serilog.Sinks.AmazonKinesis.nuspec
@@ -12,15 +12,18 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <tags>serilog logging aws amazon kinesis structured logging</tags>
     <dependencies>
-        <dependency id="AWSSDK.Core" version="3.1.5.3" />
-        <dependency id="AWSSDK.Kinesis" version="3.1.3.0" />
-        <dependency id="AWSSDK.KinesisFirehose" version="3.1.0.2" />
-        <dependency id="Serilog" version="1.5.14" />
+      <dependency id="AWSSDK.Core" version="3.1.5.3" />
+      <dependency id="AWSSDK.Kinesis" version="3.1.3.0" />
+      <dependency id="AWSSDK.KinesisFirehose" version="3.1.0.2" />
+      <dependency id="Serilog" version="2.0.0" />
+      <dependency id="Serilog.Sinks.File" version="2.2.0" />
+      <dependency id="Serilog.Sinks.PeriodicBatching" version="2.1.0" />
+      <dependency id="Serilog.Sinks.RollingFile" version="2.2.0" />
     </dependencies>
   </metadata>
   <files>
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\net40" />
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\net40" />
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\net40" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\net45" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\net45" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\net45" />
   </files>
 </package>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Sinks.Amazon.Kinesis.Tests</RootNamespace>
     <AssemblyName>Serilog.Sinks.Amazon.Kinesis.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -20,6 +21,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -28,6 +30,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
@@ -58,12 +61,12 @@
       <HintPath>..\..\packages\AutoFixture.AutoMoq.3.45.3\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net40\Serilog.dll</HintPath>
+    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.2.4.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Serilog.FullNetFx, Version=1.5.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.1.5.14\lib\net40\Serilog.FullNetFx.dll</HintPath>
+    <Reference Include="Serilog.Sinks.Trace, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Serilog.Sinks.Trace.2.1.0\lib\net45\Serilog.Sinks.Trace.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.7.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
@@ -62,7 +62,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Serilog.2.4.0\lib\net45\Serilog.dll</HintPath>
+      <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.Trace, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
@@ -34,15 +34,15 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net35\AWSSDK.Core.dll</HintPath>
+      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net45\AWSSDK.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.Kinesis, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net35\AWSSDK.Kinesis.dll</HintPath>
+      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net45\AWSSDK.Kinesis.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="AWSSDK.KinesisFirehose, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.2\lib\net35\AWSSDK.KinesisFirehose.dll</HintPath>
+      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\lib\net45\AWSSDK.KinesisFirehose.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
@@ -114,13 +114,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.1.3.0\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
-    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.1.0.2\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/app.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/app.config
@@ -1,15 +1,15 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205"/>
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205" />
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/app.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/app.config
@@ -1,11 +1,15 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205" />
+        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-4.2.1510.2205" newVersion="4.2.1510.2205"/>
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
@@ -2,11 +2,12 @@
 <packages>
   <package id="AutoFixture" version="3.45.3" targetFramework="net40" />
   <package id="AutoFixture.AutoMoq" version="3.45.3" targetFramework="net40" />
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net40" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net40" />
-  <package id="AWSSDK.KinesisFirehose" version="3.1.0.2" targetFramework="net40" />
+  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net40" requireReinstallation="true" />
+  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net40" requireReinstallation="true" />
+  <package id="AWSSDK.KinesisFirehose" version="3.1.0.2" targetFramework="net40" requireReinstallation="true" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
   <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="Serilog" version="1.5.14" targetFramework="net40" />
+  <package id="Serilog" version="2.4.0" targetFramework="net452" />
+  <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net452" />
   <package id="Shouldly" version="2.7.0" targetFramework="net40" />
 </packages>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
@@ -7,7 +7,7 @@
   <package id="AWSSDK.KinesisFirehose" version="3.1.0.3" targetFramework="net45" />
   <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Serilog" version="2.4.0" targetFramework="net45" />
+  <package id="Serilog" version="2.0.0" targetFramework="net45" />
   <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net45" />
   <package id="Shouldly" version="2.7.0" targetFramework="net45" />
 </packages>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.45.3" targetFramework="net40" />
-  <package id="AutoFixture.AutoMoq" version="3.45.3" targetFramework="net40" />
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net40" requireReinstallation="true" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net40" requireReinstallation="true" />
-  <package id="AWSSDK.KinesisFirehose" version="3.1.0.2" targetFramework="net40" requireReinstallation="true" />
-  <package id="Moq" version="4.2.1510.2205" targetFramework="net40" />
-  <package id="NUnit" version="2.6.4" targetFramework="net40" />
-  <package id="Serilog" version="2.4.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net452" />
-  <package id="Shouldly" version="2.7.0" targetFramework="net40" />
+  <package id="AutoFixture" version="3.45.3" targetFramework="net45" />
+  <package id="AutoFixture.AutoMoq" version="3.45.3" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
+  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
+  <package id="AWSSDK.KinesisFirehose" version="3.1.0.3" targetFramework="net45" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="Serilog" version="2.4.0" targetFramework="net45" />
+  <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net45" />
+  <package id="Shouldly" version="2.7.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Hello there,

This package can be used now with Serilog 2.x versions.