### PR TITLE
Upgrade target framework and dependency versions

### DIFF
--- a/sample/AmazonKinesisSample/AmazonKinesisSample.csproj
+++ b/sample/AmazonKinesisSample/AmazonKinesisSample.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>AmazonKinesisSample</RootNamespace>
     <AssemblyName>AmazonKinesisSample</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
@@ -38,21 +38,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net45\AWSSDK.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Core.3.3.18.4\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
-    <Reference Include="AWSSDK.Kinesis, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net45\AWSSDK.Kinesis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Kinesis, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Kinesis.3.3.3.2\lib\net45\AWSSDK.Kinesis.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.ColoredConsole, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.ColoredConsole.2.0.0\lib\net45\Serilog.Sinks.ColoredConsole.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -73,7 +69,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.1.3.0\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.3.3.2\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/sample/AmazonKinesisSample/App.config
+++ b/sample/AmazonKinesisSample/App.config
@@ -1,9 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <appSettings>
     <!--    <add key="AWSAccessKey" value="YOUR_ACCESS_KEY"/>-->
     <!--    <add key="AWSSecretKey" value="YOUR_SECRET_KEY"/>-->
-    <add key="AWSRegion" value="us-east-1"/>
+    <add key="AWSRegion" value="us-east-1" />
     <!--AWSProfileName is used to reference an account that has been registered with the SDK.
 If using AWS Toolkit for Visual Studio then this value is the same value shown in the AWS Explorer.
 It is also possible to register an account using the <solution-dir>/packages/AWSSDK-X.X.X.X/tools/account-management.ps1 PowerShell script
@@ -12,12 +12,16 @@ that is bundled with the nuget package under the tools folder.
 		<add key="AWSProfileName" value="" />
 -->
   </appSettings>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="AWSSDK.Core" publicKeyToken="885c28607f98e604" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-3.1.0.0" newVersion="3.1.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/sample/AmazonKinesisSample/packages.config
+++ b/sample/AmazonKinesisSample/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
-  <package id="Serilog" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.3.18.4" targetFramework="net462" />
+  <package id="AWSSDK.Kinesis" version="3.3.3.2" targetFramework="net462" />
+  <package id="Serilog" version="2.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.ColoredConsole" version="2.0.0" targetFramework="net462" />
 </packages>

--- a/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Serilog.Sinks.Amazon.Kinesis.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Sinks.Amazon.Kinesis</RootNamespace>
     <AssemblyName>Serilog.Sinks.Amazon.Kinesis</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <Framework Condition=" '$(Framework)' == '' ">NET45</Framework>
@@ -44,33 +44,26 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net45\AWSSDK.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Core.3.3.18.4\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
-    <Reference Include="AWSSDK.Kinesis, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net45\AWSSDK.Kinesis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Kinesis, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Kinesis.3.3.3.2\lib\net45\AWSSDK.Kinesis.dll</HintPath>
     </Reference>
-    <Reference Include="AWSSDK.KinesisFirehose, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\lib\net45\AWSSDK.KinesisFirehose.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.KinesisFirehose, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.3.0.1\lib\net45\AWSSDK.KinesisFirehose.dll</HintPath>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.File.2.2.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.PeriodicBatching, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.PeriodicBatching.2.1.0\lib\net45\Serilog.Sinks.PeriodicBatching.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.RollingFile.2.2.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -114,8 +107,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.1.3.0\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
-    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.3.3.2\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.3.0.1\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="AfterBuild">

--- a/src/Serilog.Sinks.Amazon.Kinesis/packages.config
+++ b/src/Serilog.Sinks.Amazon.Kinesis/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
-  <package id="AWSSDK.KinesisFirehose" version="3.1.0.3" targetFramework="net45" />
-  <package id="LibLog" version="4.2.5" targetFramework="net45" developmentDependency="true" />
-  <package id="Serilog" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.File" version="2.2.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.RollingFile" version="2.2.0" targetFramework="net45" />
+  <package id="AWSSDK.Core" version="3.3.18.4" targetFramework="net462" />
+  <package id="AWSSDK.Kinesis" version="3.3.3.2" targetFramework="net462" />
+  <package id="AWSSDK.KinesisFirehose" version="3.3.0.1" targetFramework="net462" />
+  <package id="LibLog" version="4.2.5" targetFramework="net462" developmentDependency="true" />
+  <package id="Serilog" version="2.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.File" version="2.2.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.PeriodicBatching" version="2.1.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.RollingFile" version="2.2.0" targetFramework="net462" />
 </packages>

--- a/src/Serilog.Sinks.AmazonKinesis.nuspec
+++ b/src/Serilog.Sinks.AmazonKinesis.nuspec
@@ -22,8 +22,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\net45" />
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\net45" />
-    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\net45" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.dll" target="lib\net462" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.pdb" target="lib\net462" />
+    <file src="Serilog.Sinks.Amazon.Kinesis\bin\Release\Serilog.Sinks.Amazon.Kinesis.xml" target="lib\net462" />
   </files>
 </package>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/Serilog.Sinks.Amazon.Kinesis.Tests.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Serilog.Sinks.Amazon.Kinesis.Tests</RootNamespace>
     <AssemblyName>Serilog.Sinks.Amazon.Kinesis.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -39,45 +39,35 @@
     <SignAssembly>true</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="AWSSDK.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Core.3.1.5.3\lib\net45\AWSSDK.Core.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Core.3.3.18.4\lib\net45\AWSSDK.Core.dll</HintPath>
     </Reference>
-    <Reference Include="AWSSDK.Kinesis, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.Kinesis.3.1.3.0\lib\net45\AWSSDK.Kinesis.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.Kinesis, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.Kinesis.3.3.3.2\lib\net45\AWSSDK.Kinesis.dll</HintPath>
     </Reference>
-    <Reference Include="AWSSDK.KinesisFirehose, Version=3.1.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\lib\net45\AWSSDK.KinesisFirehose.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="AWSSDK.KinesisFirehose, Version=3.3.0.0, Culture=neutral, PublicKeyToken=885c28607f98e604, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\AWSSDK.KinesisFirehose.3.3.0.1\lib\net45\AWSSDK.KinesisFirehose.dll</HintPath>
     </Reference>
     <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture, Version=3.45.3.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AutoFixture.3.45.3\lib\net40\Ploeh.AutoFixture.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Ploeh.AutoFixture.AutoMoq, Version=3.45.3.0, Culture=neutral, PublicKeyToken=b24654c590009d4f, processorArchitecture=MSIL">
       <HintPath>..\..\packages\AutoFixture.AutoMoq.3.45.3\lib\net40\Ploeh.AutoFixture.AutoMoq.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.2.0.0\lib\net45\Serilog.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Serilog.Sinks.Trace, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Serilog.Sinks.Trace.2.1.0\lib\net45\Serilog.Sinks.Trace.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="Shouldly, Version=2.7.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Shouldly.2.7.0\lib\net40\Shouldly.dll</HintPath>
-      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -123,8 +113,8 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.1.3.0\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
-    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.1.0.3\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.Kinesis.3.3.3.2\analyzers\dotnet\cs\AWSSDK.Kinesis.CodeAnalysis.dll" />
+    <Analyzer Include="..\..\packages\AWSSDK.KinesisFirehose.3.3.0.1\analyzers\dotnet\cs\AWSSDK.KinesisFirehose.CodeAnalysis.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/app.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/app.config
@@ -12,4 +12,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" /></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2" /></startup></configuration>

--- a/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
+++ b/tests/Serilog.Sinks.Amazon.Kinesis.Tests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="AutoFixture" version="3.45.3" targetFramework="net45" />
-  <package id="AutoFixture.AutoMoq" version="3.45.3" targetFramework="net45" />
-  <package id="AWSSDK.Core" version="3.1.5.3" targetFramework="net45" />
-  <package id="AWSSDK.Kinesis" version="3.1.3.0" targetFramework="net45" />
-  <package id="AWSSDK.KinesisFirehose" version="3.1.0.3" targetFramework="net45" />
-  <package id="Moq" version="4.2.1510.2205" targetFramework="net45" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
-  <package id="Serilog" version="2.0.0" targetFramework="net45" />
-  <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net45" />
-  <package id="Shouldly" version="2.7.0" targetFramework="net45" />
+  <package id="AutoFixture" version="3.45.3" targetFramework="net462" />
+  <package id="AutoFixture.AutoMoq" version="3.45.3" targetFramework="net462" />
+  <package id="AWSSDK.Core" version="3.3.18.4" targetFramework="net462" />
+  <package id="AWSSDK.Kinesis" version="3.3.3.2" targetFramework="net462" />
+  <package id="AWSSDK.KinesisFirehose" version="3.3.0.1" targetFramework="net462" />
+  <package id="Moq" version="4.2.1510.2205" targetFramework="net462" />
+  <package id="NUnit" version="2.6.4" targetFramework="net462" />
+  <package id="Serilog" version="2.0.0" targetFramework="net462" />
+  <package id="Serilog.Sinks.Trace" version="2.1.0" targetFramework="net462" />
+  <package id="Shouldly" version="2.7.0" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
I found this necessary for my own use in a 4.6 Framework application with a lot of nuget dependencies to manage, not sure what downstream concerns would effect the wider community.