### PR TITLE
Set _throttlingTime as period repameter and zero as dueTime to timer …

### DIFF
--- a/src/Serilog.Sinks.Amazon.Kinesis/Common/Throttle.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Common/Throttle.cs
@@ -48,7 +48,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Common
             if (Interlocked.CompareExchange(ref _throttling, THROTTLING_BUSY, THROTTLING_FREE) == THROTTLING_FREE)
             {
                 _running = true;
-                return _timer.Change(_throttlingTime, new TimeSpan(0, 0, 0, 0, Timeout.Infinite));
+                return _timer.Change(period: _throttlingTime, dueTime: new TimeSpan(0, 0, 0, 0, 0));
             }
             return false;
         }


### PR DESCRIPTION
…in Throttle type.

Description: when fist time calling ThrottleAction method we need set up timer to wirking and in Stop method need shutdown it, but we set only dueTime with throttlingTime value and never don't reset the _throttling value or restart timer. The timer work once at application start and go to off. Application logs after the first operation are no longer written to Kinesis