### PR TITLE
Fix throttling to free when the callback it's done

### DIFF
--- a/src/Serilog.Sinks.Amazon.Kinesis/Common/Throttle.cs
+++ b/src/Serilog.Sinks.Amazon.Kinesis/Common/Throttle.cs
@@ -34,6 +34,7 @@ namespace Serilog.Sinks.Amazon.Kinesis.Common
                 if (_running)
                 {
                     _callback();
+                    _throttling = THROTTLING_FREE;
                 }
             }
         }


### PR DESCRIPTION
When ThrottleAction it's call Interlocked.CompareExchange() change the _throttling to be BUSY, but never it's FREE after that.

So when the callback it's called and finish i put the _throttling to be FREE.